### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/app/routes/admin.quiz-edit.tsx
+++ b/frontend/app/routes/admin.quiz-edit.tsx
@@ -187,6 +187,10 @@ export default function AdminQuizEditPage() {
 
     // Create preview URL
     const preview = URL.createObjectURL(file);
+    if (!preview.startsWith('blob:')) {
+      setError('Ungültige Datei-URL.');
+      return;
+    }
     setUploadedImage({
       file,
       preview,
@@ -703,6 +707,8 @@ export default function AdminQuizEditPage() {
                       <img
                         src={uploadedImage.preview}
                         alt="Hochgeladenes Bild"
+                        loading="lazy"
+                        referrerPolicy="no-referrer"
                         className="h-20 w-20 object-cover rounded-lg border border-gray-600"
                       />
                       <div className="flex-1">


### PR DESCRIPTION
Potential fix for [https://github.com/paifgx/quizdom/security/code-scanning/1](https://github.com/paifgx/quizdom/security/code-scanning/1)

The best way to address the issue is to validate and sanitize the `preview` URL before assigning it to the `src` attribute of the `<img>` element. This involves ensuring that the generated URL is safe and originates from a trusted source. Additionally, wrapping the `<img>` element with a strict Content Security Policy (CSP) can further reduce the risk of exploitation.

Changes will be made to:
- Validate the `preview` URL before using it.
- Ensure the `<img>` element safely displays the preview image.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
