### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/paifgx/quizdom/security/code-scanning/3](https://github.com/paifgx/quizdom/security/code-scanning/3)

To resolve the issue, add the `permissions` key to the workflow. Since this workflow involves operations like checking out the repository, caching dependencies, and fetching the lock file, it primarily requires `contents: read`. No write permissions appear necessary for any part of the workflow. The `permissions` key should be added at the root level of the workflow to apply to all jobs unless overridden locally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
