### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/paifgx/quizdom/security/code-scanning/2](https://github.com/paifgx/quizdom/security/code-scanning/2)

To address the issue, we will add a `permissions` block to the root of the workflow file. Since the workflow performs tasks like linting and formatting code, it only requires `contents: read` permission to access the repository contents. We will add the `permissions` key at the root level to apply this minimal privilege to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
