### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/paifgx/quizdom/security/code-scanning/4](https://github.com/paifgx/quizdom/security/code-scanning/4)

To resolve the issue, explicit permissions should be added to the workflow. Since the workflow appears to involve reading repository contents (e.g., using `actions/checkout`), but does not require write operations to the repository, the permissions should be set to `contents: read`. This ensures that the `GITHUB_TOKEN` is limited to only the required access.

The permissions block can be added at the root level of the workflow file to apply to all jobs or within specific jobs if different permissions are needed for each. In this case, a root-level permissions block is recommended for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
